### PR TITLE
Optionally enable reverse geocoding

### DIFF
--- a/LocationPicker/LocationItem.swift
+++ b/LocationPicker/LocationItem.swift
@@ -90,7 +90,8 @@ public class LocationItem: NSObject, NSCoding {
         /// - Note: If you would like to format the address yourself, you can use `addressDictionary` property to create one.
     public var formattedAddressString: String? {
         get {
-            return (addressDictionary?["FormattedAddressLines"] as? [String])?[0]
+            let addressParts = (addressDictionary?["FormattedAddressLines"] as? [String])
+            return addressParts?.count > 1 ? addressParts?[1] : addressParts?[0]
         }
     }
     

--- a/LocationPicker/LocationPicker.swift
+++ b/LocationPicker/LocationPicker.swift
@@ -727,6 +727,20 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
     }
     
     
+    /**
+     This method would be called whenever a user selects search result or an alternative location from the table view.
+     If you return true, the location will be reverse geocoded. This is helpful if you require an exact
+     location (e.g. providing street), but the user just searched for a town name.
+     The default behavior is to not geocode any additional search result.
+     
+     - parameter locationItem `LocationItem` LocationItem that the user selected
+     - return `Bool` Whether to force reverse geocoding or not
+     */
+    public func forceReverseGeocoding(locationItem: LocationItem) -> Bool {
+        return false
+    }
+    
+    
     
     // MARK: - Gesture Recognizer
     
@@ -866,7 +880,12 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
         } else {
             let cell = tableView.cellForRowAtIndexPath(indexPath) as! LocationCell
             let locationItem = cell.locationItem!
-            selectLocationItem(locationItem)
+            let coordinate = locationItem.coordinate
+            if coordinate != nil && self.forceReverseGeocoding(locationItem) {
+                reverseGeocodeLocation(CLLocation(latitude: coordinate!.latitude, longitude: coordinate!.longitude))
+            } else {
+                selectLocationItem(locationItem)
+            }
         }
         
     }

--- a/LocationPicker/LocationPicker.swift
+++ b/LocationPicker/LocationPicker.swift
@@ -771,6 +771,7 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
     
     // MARK: Search Bar Delegate
     
+    
     public func searchBar(searchBar: UISearchBar, textDidChange searchText: String) {
         if searchText.characters.count > 0 {
             let localSearchRequest = MKLocalSearchRequest()
@@ -792,7 +793,9 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
                         return
                 }
                 
-                self.searchResultLocations = localSearchResponse.mapItems.map({ LocationItem(mapItem: $0) })
+                self.searchResultLocations = localSearchResponse.mapItems.filter({ (mapItem) -> Bool in
+                    return self.shouldShowSearchResult(mapItem)
+                }).map({ LocationItem(mapItem: $0) })
                 
                 if self.allowArbitraryLocation {
                     let locationFound = self.searchResultLocations.filter({
@@ -823,6 +826,15 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
         searchBar.endEditing(true)
     }
     
+    
+    /**
+     Decide if an item from MKLocalSearch should be displayed or not
+     
+     - parameter locationItem:      An instance of `LocationItem`
+     */
+    public func shouldShowSearchResult(mapItem: MKMapItem) -> Bool {
+        return true
+    }
     
     
     // MAKR: Table View Delegate and Data Source

--- a/LocationPicker/LocationPicker.swift
+++ b/LocationPicker/LocationPicker.swift
@@ -987,7 +987,12 @@ public class LocationPicker: UIViewController, UISearchBarDelegate, UITableViewD
     
     // MARK: Location Handlers
     
-    private func selectLocationItem(locationItem: LocationItem) {
+    /**
+     Set the given LocationItem as the currently selected one. This will update the searchBar and show the map if possible.
+     
+     - parameter locationItem:      An instance of `LocationItem`
+     */
+    public func selectLocationItem(locationItem: LocationItem) {
         selectedLocationItem = locationItem
         searchBar.text = locationItem.name
         if let coordinate = locationItem.coordinate {

--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ override func locationDidDeny(locationPicker: LocationPicker) {
 }
 ```
 
+##### Reverse geocoding
+
+By default, reverse geocoding (obtaining an address for a location) will only be performed for the current location and whenever the user drags the map to select a new address. There are cases in which a search result can contain a city name but no street name. However, an exact position will be marked on the map. By overriding the following method, you can force reverse geocoding:
+
+```swift
+override public func forceReverseGeocoding(locationItem: LocationItem) -> Bool {
+    // in this case, reverse geocoding will always be performed if the street is not present
+    return locationItem.addressDictionary?["Street"] == nil
+}
+```
+
+
 ## Location Item
 
 `LocationItem` is a encapsulation class of `MKMapItem` to save you from importing `MapKit` everywhere in your project. To make it more convenient to use, it equips with several computing properties to access the `MKMapItem`.


### PR DESCRIPTION
I've added an option to enable reverse geocoding for search results and alternative results in order to get an exact address (e.g. with a street name).
