### PR TITLE
Check if parent is nav controller

### DIFF
--- a/LocationPicker/LocationPicker.swift
+++ b/LocationPicker/LocationPicker.swift
@@ -615,13 +615,21 @@ open class LocationPicker: UIViewController, UIGestureRecognizerDelegate {
     
     func doneButtonDidTap(barButtonItem: UIBarButtonItem) {
         if let locationItem = selectedLocationItem {
-            dismiss(animated: true, completion: nil)
+            if let navigationController = navigationController {
+                navigationController.popViewController(animated: true)
+            }else{
+                dismiss(animated: true, completion: nil)
+            }
             locationDidPick(locationItem: locationItem)
         }
     }
     
     func cancelButtonDidTap(barButtonItem: UIBarButtonItem) {
-        dismiss(animated: true, completion: nil)
+        if let navigationController = navigationController {
+            navigationController.popViewController(animated: true)
+        } else {
+            dismiss(animated: true, completion: nil)
+        }
     }
     
     


### PR DESCRIPTION
This fixes a bug that prevents the location picker being dismissed in a nav controller