### PR TITLE
Fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,15 @@
+// swift-tools-version:5.0
 import PackageDescription
 
-let package = Package(name: "LocationPicker")
+let package = Package(
+    name: "LocationPicker",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(name: "LocationPicker", targets: ["LocationPicker"])
+    ],
+    targets: [
+        .target(name: "LocationPicker", dependencies: [], path: "./LocationPicker"),
+    ]
+)


### PR DESCRIPTION
Add required metadata for Package.swift to work with Xcode and SPM.

All data matches what is included in the .podspec.
- Platforms: > iOS 8.0
- `LocationPicker` product & target
- Minimum Swift version of 5.0 (required for SPM to work anyways)